### PR TITLE
fixed browser classes

### DIFF
--- a/byu_d8.theme
+++ b/byu_d8.theme
@@ -46,7 +46,34 @@ function byu_d8_browser_classes() {
 
     // Checks browsers in this order: Chrome, Safari, Opera, MSIE, FF
     // Then, get the browser's version number
-    if (preg_match("/Chrome/", $browser)) {
+    if (preg_match("/Opera/", $browser)) {
+        $classes[] = 'opera';
+        preg_match("/Opera\/(\d.\d)/si", $browser, $matches);
+        $op_version = 'op' . str_replace('.', '-', $matches[1]);
+        $classes[] = $op_version;
+    }
+    elseif (preg_match("/Trident/", $browser) || preg_match("/MSIE/", $browser)) {
+        $classes[] = 'internet-explorer';
+        if (preg_match("/MSIE 6.0/", $browser) || preg_match("/MSIE 6.1/", $browser)) $classes[] = 'ie6';
+        elseif (preg_match("/MSIE 7.0/", $browser)) $classes[] = 'ie7';
+        elseif (preg_match("/MSIE 8.0/", $browser)) $classes[] = 'ie8';
+        elseif (preg_match("/MSIE 9.0/", $browser)) $classes[] = 'ie9';
+        elseif (preg_match("/MSIE 10.0/", $browser)) $classes[] = 'ie10';
+        elseif (preg_match("/rv:11.0/", $browser)) $classes[] = 'ie11';
+    }
+    elseif (preg_match("/Edge/", $browser)) {
+            $classes[] = 'edge';
+            preg_match("/Edge\/(\d.\d)/si", $browser, $matches);
+            $ed_version = 'ed' . str_replace('.', '-', $matches[1]);
+            $classes[] = $ed_version;
+    }
+    elseif (preg_match("/Firefox/", $browser)) {
+        $classes[] = 'firefox';
+        preg_match("/Firefox\/(\d)/si", $browser, $matches);
+        $ff_version = 'ff' . str_replace('.', '-', $matches[1]);
+        $classes[] = $ff_version;
+    }
+    elseif (preg_match("/Chrome/", $browser)) {
         $classes[] = 'chrome';
         preg_match("/Chrome\/(\d.\d)/si", $browser, $matches);
         $ch_version = 'ch' . str_replace('.', '-', $matches[1]);
@@ -57,30 +84,6 @@ function byu_d8_browser_classes() {
         preg_match("/Version\/(\d.\d)/si", $browser, $matches);
         $sf_version = 'sf' . str_replace('.', '-', $matches[1]);
         $classes[] = $sf_version;
-    }
-    elseif (preg_match("/Opera/", $browser)) {
-        $classes[] = 'opera';
-        preg_match("/Opera\/(\d.\d)/si", $browser, $matches);
-        $op_version = 'op' . str_replace('.', '-', $matches[1]);
-        $classes[] = $op_version;
-    }
-    elseif (preg_match("/MSIE/", $browser)) {
-        $classes[] = 'msie';
-        if (preg_match("/MSIE 6.0/", $browser)) $classes[] = 'ie6';
-        elseif (preg_match("/MSIE 7.0/", $browser)) $classes[] = 'ie7';
-        elseif (preg_match("/MSIE 8.0/", $browser)) $classes[] = 'ie8';
-    }
-    elseif (preg_match("/Firefox/", $browser) && preg_match("/Gecko/", $browser)) {
-        $classes[] = 'firefox';
-        preg_match("/Firefox\/(\d)/si", $browser, $matches);
-        $ff_version = 'ff' . str_replace('.', '-', $matches[1]);
-        $classes[] = $ff_version;
-    }
-    elseif (preg_match("/Namoroka/", $browser) && preg_match("/Gecko/", $browser)) {
-        $classes[] = 'firefox';
-        preg_match("/Namoroka\/(\d)/si", $browser, $matches);
-        $ff_version = 'ff' . str_replace('.', '-', $matches[1]);
-        $classes[] = $ff_version;
     }
     else $classes[] = 'unknown-browser';
 


### PR DESCRIPTION
now recognizes and prints all major browsers, but only prints a version
number for Firefox and IE (unsure why not printing for other browsers).

Purposely re-ordered browsers since "Chrome" and "Safari" may appear in other browsers for compatibility.